### PR TITLE
Onefit frontend workflows

### DIFF
--- a/.github/workflows/build-and-types.yml
+++ b/.github/workflows/build-and-types.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build_and_types:
     name: Build and TSC
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, deploy]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/build-and-types.yml
+++ b/.github/workflows/build-and-types.yml
@@ -1,0 +1,35 @@
+name: Build and Types
+on:
+  workflow_call:
+    secrets:
+      GH_PACKAGES_TOKEN:
+        required: true
+jobs:
+  build_and_types:
+    name: Build and TSC
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      # Restore NPM cache
+      - name: Restore node_modules
+        uses: actions/cache@v3
+        id: node-cache
+        with:
+          path: |
+            ./node_modules
+            /home/runner/.cache/Cypress
+          key: node-cache-${{ runner.os }}-${{ hashFiles('./yarn.lock') }}
+      - name: Set Node version
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://npm.pkg.github.com"
+      - name: Install NPM dependencies
+        if: steps.node-cache.outputs.cache-hit != 'true'
+        run: yarn
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+      # Build
+      - name: Build
+        run: yarn build

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   e2e_tests:
     name: Cypress
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, deploy]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,35 @@
+name: E2E Tests
+on:
+  workflow_call:
+    secrets:
+      GH_PACKAGES_TOKEN:
+        required: true
+jobs:
+  e2e_tests:
+    name: Cypress
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      # Restore NPM cache
+      - name: Restore node_modules
+        uses: actions/cache@v3
+        id: node-cache
+        with:
+          path: |
+            ./node_modules
+            /home/runner/.cache/Cypress
+          key: node-cache-${{ runner.os }}-${{ hashFiles('./yarn.lock') }}
+      - name: Set Node version
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://npm.pkg.github.com"
+      - name: Install NPM dependencies
+        if: steps.node-cache.outputs.cache-hit != 'true'
+        run: yarn
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+      # E2E Tests
+      - name: Cypress
+        run: yarn cy:run

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Lint
+on:
+  workflow_call:
+    secrets:
+      GH_PACKAGES_TOKEN:
+        required: true
+jobs:
+  lint:
+    name: ESLint and StyleLint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      # Restore NPM cache
+      - name: Restore node_modules
+        uses: actions/cache@v3
+        id: node-cache
+        with:
+          path: |
+            ./node_modules
+            /home/runner/.cache/Cypress
+          key: node-cache-${{ runner.os }}-${{ hashFiles('./yarn.lock') }}
+      - name: Set Node version
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://npm.pkg.github.com"
+      - name: Install NPM dependencies
+        if: steps.node-cache.outputs.cache-hit != 'true'
+        run: yarn
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+      # Lint
+      - name: ESLint
+        run: yarn lint
+      - name: StyleLint
+        run: yarn lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   lint:
     name: ESLint and StyleLint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, deploy]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,35 @@
+name: Unit Tests
+on:
+  workflow_call:
+    secrets:
+      GH_PACKAGES_TOKEN:
+        required: true
+jobs:
+  unit_tests:
+    name: Jest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      # Restore NPM cache
+      - name: Restore node_modules
+        uses: actions/cache@v3
+        id: node-cache
+        with:
+          path: |
+            ./node_modules
+            /home/runner/.cache/Cypress
+          key: node-cache-${{ runner.os }}-${{ hashFiles('./yarn.lock') }}
+      - name: Set Node version
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://npm.pkg.github.com"
+      - name: Install NPM dependencies
+        if: steps.node-cache.outputs.cache-hit != 'true'
+        run: yarn
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+      # Unit Tests
+      - name: Jest
+        run: yarn jest:run

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   unit_tests:
     name: Jest
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, deploy]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2


### PR DESCRIPTION
These are 4 workflows that we use in the new OneFit frontend projects. The projects are mostly React and Next.js
The workflows include:
- [.github/workflows/build-and-types.yml](https://github.com/urbansportsclub/usc-reusable-workflows/pull/8/files#diff-cbf32240c18489c7b6f1fc9c92757486dbc78c3aaf84a0ec7a4bdd9bac9be24d) for checking types and making sure the build passes. It invokes `yarn build` in the project root which usually uses CRA or Next in the projects to check the types and build the project.
- [.github/workflows/lint.yml](https://github.com/urbansportsclub/usc-reusable-workflows/pull/8/files#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2) for lining the project. We have a pretty standard, but extensive linter setup with ESLint and StyleLint. This makes sure both of those are passing without errors.
- [.github/workflows/unit-tests.yml](https://github.com/urbansportsclub/usc-reusable-workflows/pull/8/files#diff-cd0effce06f425599e96952f4d5f684641a683f46d9909e7c74a9f8b2f03ccd3) is pretty self-explanatory. Uses Jest and runs the tests and fails if the code on the branch does not meet coverage thresholds. (I will set up Codecov on the new frontend repos in the next day or two)
- [.github/workflows/e2e-tests.yml](https://github.com/urbansportsclub/usc-reusable-workflows/pull/8/files#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3) is just Cypress being Cypress :)