### PR TITLE
Upgrade Cypress in e2e-tests.yml

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -43,7 +43,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
       # E2E Tests
       - name: Cypress
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         with:
           build: yarn build
           start: yarn start


### PR DESCRIPTION
The new Cypress update changed the API and broke this action. Maybe this will fix it? Can we merge to test? If not I'll investigate further.