### PR TITLE
Add buil-args as supported input

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yaml
+++ b/.github/workflows/build-and-push-docker-image.yaml
@@ -46,6 +46,11 @@ on:
         type: string
         description: "Working directory for github runner"
         default: "/"
+      build_args:
+        required: false
+        type: string
+        description: "List of build-time variables"
+        default: ""
 
 jobs:
   buildandpushdocker:
@@ -98,6 +103,7 @@ jobs:
         platforms: ${{ inputs.platforms }}
         push: true
         tags: ${{ steps.subscriber_meta.outputs.tags }}
+        build-args: ${{ steps.subscriber_meta.outputs.build_args }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new


### PR DESCRIPTION
For go applications, when we want to import a private library (in our case #urbansportsclub/gokit) we need to pass build-time arguments to Docker.

An example of what that will look like:

```yaml
  build:
    uses: urbansportsclub/usc-reusable-workflows/.github/workflows/build-and-push-docker-image.yaml@main
    with:
      repository: my-service
      image: my-service
      project_id: urbansportsclub-dev
      dockerfile_path: "Dockerfile"
      build_args: |
        GITHUB_TOKEN=${{ secrets.GB_TOKEN_PRIVATE }}
```