### PR TITLE
Add environment

### DIFF
--- a/.github/workflows/deploy-to-k8s-cluster.yaml
+++ b/.github/workflows/deploy-to-k8s-cluster.yaml
@@ -81,6 +81,7 @@ jobs:
   deploy-to-k8s:
     name: Deploy to Kubernetes Cluster
     runs-on: [self-hosted, "${{ inputs.runner }}"]
+    environment: ${{ inputs.stage }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
When we deploy with this action, we don't know the flag to GitHub in which environment the deployment happened.
 
This PR will generate a deployment event for the four key metrics we want to track.