### PR TITLE
add new reusable workflow for testing golang apps

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -1,0 +1,30 @@
+---
+on:
+  workflow_call:
+
+jobs:
+  test:
+    name: Test
+    runs-on: [self-hosted, vm]
+    timeout-minutes: 15
+
+    steps:
+    - name: Setup go
+      uses: actions/setup-go@v3
+      with:
+        go-version: "stable"
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Test
+      run: make test
+      env:
+        GITHUB_TOKEN: ${{ secrets.GB_TOKEN_PRIVATE }}

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -1,6 +1,9 @@
 ---
 on:
   workflow_call:
+    secrets:
+      github-token:
+        required: true
 
 jobs:
   test:
@@ -25,6 +28,6 @@ jobs:
           ${{ runner.os }}-go-
 
     - name: Test
-      run: make test
+      run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
       env:
-        GITHUB_TOKEN: ${{ secrets.GB_TOKEN_PRIVATE }}
+        GITHUB_TOKEN: ${{ secrets.github-token }}

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: [self-hosted, vm]
+    runs-on: [self-hosted, nonroot]
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
Added a new reusable workflow to be used for the go services.

We already have an existing one, but that one is for Javascript and it is used only for [urbansports/usg-web-careers](https://github.com/urbansportsclub/usg-web-careers/blob/2be323d7c4f5dde96c34412d2db5e3ab8639ecc3/.github/workflows/ci.yml#L20) and [urbansports/onefit-web-b2b](https://github.com/urbansportsclub/onefit-web-b2b/blob/8ce06070c637c3c6b06e41f60e0732722d0a384b/.github/workflows/ci.yml#L19)

Search result:
https://github.com/search?q=org%3Aurbansportsclub++%22urbansportsclub%2Fusc-reusable-workflows%2F.github%2Fworkflows%2Funit-tests%22&type=code

Usage:
```yaml
reusable-test:
  name: Test
  uses: urbansportsclub/usc-reusable-workflows/.github/workflows/test-go.yaml@main
  secrets: inherit
```