### PR TITLE
Update test-go workflow to expose the runner and add GH config

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -1,0 +1,30 @@
+---
+on:
+  workflow_call:
+
+jobs:
+  test:
+    name: Test
+    runs-on: [self-hosted, vm]
+    timeout-minutes: 15
+
+    steps:
+    - name: Setup go
+      uses: actions/setup-go@v3
+      with:
+        go-version: "stable"
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Test
+      run: make test
+      env:
+        GITHUB_TOKEN: ${{ secrets.GB_TOKEN_PRIVATE }}

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -1,12 +1,6 @@
 ---
 on:
   workflow_call:
-    inputs:
-      runner:
-        required: false
-        type: string
-        description: "Runner type [default 'dind']."
-        default: "dind"
     secrets:
       github-token:
         required: true
@@ -14,7 +8,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: [self-hosted, "${{ inputs.runner }}"]
+    runs-on: [self-hosted, dind]
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -1,6 +1,9 @@
 ---
 on:
   workflow_call:
+    secrets:
+      github-token:
+        required: true
 
 jobs:
   test:
@@ -25,6 +28,6 @@ jobs:
           ${{ runner.os }}-go-
 
     - name: Test
-      run: make test
+      run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
       env:
-        GITHUB_TOKEN: ${{ secrets.GB_TOKEN_PRIVATE }}
+        GITHUB_TOKEN: ${{ secrets.github-token }}

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -26,12 +26,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    # - uses: actions/cache@v3
-    #   with:
-    #     path: ~/go/pkg/mod
-    #     key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-go-
+    - uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     - name: Configure private repo
       run: git config --global url."https://${{ secrets.github-token }}:x-oauth-basic@github.com/urbansportsclub".insteadOf "https://github.com/urbansportsclub"

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -5,6 +5,9 @@ on:
       github-token:
         required: true
 
+env:
+  GOPRIVATE: "github.com/urbansportsclub/*"
+
 jobs:
   test:
     name: Test
@@ -26,6 +29,9 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+
+    - name: Configure private repo
+      run: git config --global url."https://${{ secrets.github-token }}:x-oauth-basic@github.com/urbansportsclub".insteadOf "https://github.com/urbansportsclub"
 
     - name: Test
       run: go test -race -covermode=atomic -coverprofile=coverage.out ./...

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: [self-hosted, vm]
+    runs-on: [self-hosted, nonroot]
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
Expose the `runner` to allow running the tests on different runners if necessary.
- The execution of this workflow on `nonroot` fails due to the missing `gcc` executable: https://github.com/urbansportsclub/invoice-srv/actions/runs/3740175590/jobs/6348330226#step:6:96

Also, including the `Configure private repo` which was missing from the initial implementation.