### PR TITLE
add ignore missing schemas for kubeconform validation

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -31,3 +31,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.github-token }}
           DEFAULT_BRANCH: ${{ inputs.branch }}
           VALIDATE_ALL_CODEBASE: false
+          KUBERNETES_KUBECONFORM_OPTIONS: "-ignore-missing-schemas"


### PR DESCRIPTION
This is one of the few env vars for super linter that doesn't support a configuration file. All the other languages/technologies that we use at USG can be configured via a config file in `.github/linters`