### PR TITLE
add also kubeval for current v4 version

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -32,3 +32,4 @@ jobs:
           DEFAULT_BRANCH: ${{ inputs.branch }}
           VALIDATE_ALL_CODEBASE: false
           KUBERNETES_KUBECONFORM_OPTIONS: "-ignore-missing-schemas"
+          KUBERNETES_KUBEVAL_OPTIONS: "--ignore-missing-schemas"


### PR DESCRIPTION
KUBEVAL was removed [here](https://github.com/github/super-linter/pull/3800/files) but they haven't yet created a new release that has it, today the latest version is [v4.10.1](https://github.com/github/super-linter/releases/tag/v4.10.1).

The new option is just to support the BC that will happen.