### PR TITLE
disable super linter golang lint and use golangci-lint instead

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   build:
     runs-on: [self-hosted, nonroot]
-    name: Lint Code Base
+    name: Code Base
 
     steps:
       - name: Checkout Code
@@ -35,6 +35,35 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.github-token }}
           DEFAULT_BRANCH: ${{ inputs.branch }}
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_GO: false
           KUBERNETES_KUBECONFORM_OPTIONS: "-ignore-missing-schemas"
           KUBERNETES_KUBEVAL_OPTIONS: "--ignore-missing-schemas"
           VALIDATE_JSCPD: ${{ inputs.enable_jscpd }}
+
+  golang:
+    name: Golang files
+    runs-on: [self-hosted, nonroot]
+    timeout-minutes: 15
+
+    steps:
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "stable"
+
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure private repo
+        run: git config --global url."https://${{ secrets.github-token }}:x-oauth-basic@github.com/urbansportsclub".insteadOf "https://github.com/urbansportsclub"
+
+      - name: Golangci Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          only-new-issues: true
+          args: -c ./.github/linters/.golangci.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.github-token }}

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -23,7 +23,7 @@ on:
 jobs:
   build:
     runs-on: [self-hosted, nonroot]
-    name: Code Base
+    name: Lint Code Base
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -15,6 +15,10 @@ on:
         required: false
         type: boolean
         default: true
+      enable_go:
+        require: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -41,7 +45,8 @@ jobs:
           VALIDATE_JSCPD: ${{ inputs.enable_jscpd }}
 
   golang:
-    name: Golang files
+    if: inputs.enable_go == true
+    name: Lint Golang Files
     runs-on: [self-hosted, nonroot]
     timeout-minutes: 15
 
@@ -59,7 +64,7 @@ jobs:
       - name: Configure private repo
         run: git config --global url."https://${{ secrets.github-token }}:x-oauth-basic@github.com/urbansportsclub".insteadOf "https://github.com/urbansportsclub"
 
-      - name: Golangci Lint
+      - name: Lint Code Base
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest


### PR DESCRIPTION
Due to an issue with super-linter that doesn't execute the `golangci-lint` properly, sometimes it might isolate changes and this will trigger a specific lint called `typecheck`, which validates to see if a function/struct/const/etc... really exists or not. Because super-lint only is triggered to the modified files, you might have a problem to be linting a file that doesn't create that property, but instead, only use it.

To bypass that, we can use the golangci-lint action instead, which will validate the whole source code and ensuring that we will not lose context in the lint process.

**resources**
https://github.com/github/super-linter/issues/3596
https://github.com/golangci/golangci-lint/issues/1909
https://github.com/github/super-linter/issues/143