### PR TITLE
Default false for specific linter validation

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -14,7 +14,7 @@ on:
       enable_jscpd:
         required: false
         type: boolean
-        default: true
+        default: false
       enable_go:
         required: false
         type: boolean
@@ -34,7 +34,7 @@ on:
       enable_sqlfluff:
         required: false
         type: boolean
-        default: true
+        default: false
 
 jobs:
   build:


### PR DESCRIPTION
We found that having some linters enabled by default to true and others on false it will fail ([like in this PR](https://github.com/urbansportsclub/invoice-srv/actions/runs/4240919389/jobs/7370494071#step:5:76)) based on the documentation from super-linter.

> ## Environment variables
> 
> The super-linter allows you to pass the following `ENV` variables to be able to trigger different functionality.
> 
> _Note:_ All the `VALIDATE_[LANGUAGE]` variables behave in a very specific way:
> 
> - If none of them are passed, then they all default to true.
> - If any one of the variables are set to true, we default to leaving any unset variable to false (only validate those languages).
> - If any one of the variables are set to false, we default to leaving any unset variable to true (only exclude those languages).
> - If there are `VALIDATE_[LANGUAGE]` variables set to both true and false. It will fail.
> 
> This means that if you run the linter "out of the box", all languages will be checked.
> But if you wish to select or exclude specific linters, we give you full control to choose which linters are run, and won't run anything unexpected.
