### PR TITLE
Set sonar.projectVersion

### DIFF
--- a/.github/workflows/sonarqube-scan.yaml
+++ b/.github/workflows/sonarqube-scan.yaml
@@ -23,9 +23,6 @@ on:
         required: false
         type: string
         default: coverage-artifact
-      branch_version: 
-        required: false
-        type: string
 
 jobs:
   build:
@@ -44,17 +41,9 @@ jobs:
           name: ${{ inputs.coverage_artifact_name }}
 
       - name: Scan
-        if: inputs.branch_version == ''
-        uses: sonarsource/sonarqube-scan-action@master
-        env:
-          SONAR_TOKEN: ${{ secrets.token }}
-          SONAR_HOST_URL: ${{ inputs.url }}
-
-      - name: Scan
-        if: inputs.branch_version != ''
         uses: sonarsource/sonarqube-scan-action@master
         with:
-          args: -Dsonar.projectVersion=${{ inputs.branch_version }}
+          args: -Dsonar.projectVersion=${{ github.sha }}
         env:
           SONAR_TOKEN: ${{ secrets.token }}
           SONAR_HOST_URL: ${{ inputs.url }}

--- a/.github/workflows/sonarqube-scan.yaml
+++ b/.github/workflows/sonarqube-scan.yaml
@@ -23,6 +23,9 @@ on:
         required: false
         type: string
         default: coverage-artifact
+      branch_version: 
+        required: false
+        type: string
 
 jobs:
   build:
@@ -40,7 +43,18 @@ jobs:
         with:
           name: ${{ inputs.coverage_artifact_name }}
 
-      - uses: sonarsource/sonarqube-scan-action@master
+      - name: Scan
+        if: inputs.branch_version == ''
+        uses: sonarsource/sonarqube-scan-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.token }}
+          SONAR_HOST_URL: ${{ inputs.url }}
+
+      - name: Scan
+        if: inputs.branch_version != ''
+        uses: sonarsource/sonarqube-scan-action@master
+        with:
+          args: -Dsonar.projectVersion=${{inputs.branch_version}}
         env:
           SONAR_TOKEN: ${{ secrets.token }}
           SONAR_HOST_URL: ${{ inputs.url }}

--- a/.github/workflows/sonarqube-scan.yaml
+++ b/.github/workflows/sonarqube-scan.yaml
@@ -54,7 +54,7 @@ jobs:
         if: inputs.branch_version != ''
         uses: sonarsource/sonarqube-scan-action@master
         with:
-          args: -Dsonar.projectVersion=${{inputs.branch_version}}
+          args: -Dsonar.projectVersion=${{ inputs.branch_version }}
         env:
           SONAR_TOKEN: ${{ secrets.token }}
           SONAR_HOST_URL: ${{ inputs.url }}


### PR DESCRIPTION
This will help us to identify and work properly on SonarQube, allowing us to separate new changes from version to version, instead getting quality gate automatically fired because it gets every change from previous and actual as new changes since there is no new version tagged.

![SCR-20230418-wu2](https://user-images.githubusercontent.com/1439984/232911016-ca3acb78-6719-4a74-a075-9c9c497a9ff1.png)
