### PR TITLE
Rename sonarqube token variable name

### DIFF
--- a/.github/workflows/sonarqube-scan.yaml
+++ b/.github/workflows/sonarqube-scan.yaml
@@ -3,9 +3,6 @@ name: Sonarqube
 
 on:
   workflow_call:
-    secrets:
-      token:
-        required: true
     inputs:
       url:
         required: false
@@ -45,7 +42,7 @@ jobs:
         with:
           args: -Dsonar.projectVersion=${{ github.sha }}
         env:
-          SONAR_TOKEN: ${{ secrets.token }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ inputs.url }}
 
       # If you wish to fail your job when the Quality Gate is red, uncomment the
@@ -54,4 +51,4 @@ jobs:
         if: inputs.enable_quality_gate == true
         timeout-minutes: 5
         env:
-          SONAR_TOKEN: ${{ secrets.token }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -102,21 +102,11 @@ jobs:
 
 ![selecting the project](resources/readme/selecting-project.png)
 
-4. Select `GitHub Actions` to set up the repository and generate a `SONAR_TOKEN` to send data from your repository.
-
-![github actions](resources/readme/github-actions.png)
-
-5. Copy the token and go to your repository in GitHub, then set a new secret with the name `SONAR_TOKEN` and paste the token.
-
-![secrets](resources/readme/project-secrets.png)
-
-![github secrets](resources/readme/github-secrets.png)
-
-6. Return to the SonarQube page and click `Continue` to finish the tutorial.
-
-7. Retrieve the `Project key` by clicking the `Project information` link in the top right corner of the project page and copying the value.
+4. Retrieve the `Project key` by clicking the `Project information` link in the top right corner of the project page and copying the value.
 
 ![project information](resources/readme/project-information.png)
+
+> **_NOTE:_**  You don't need to generate a SONAR_TOKEN as we are using a global analysis token and it is added at the organization level.
 
 ### Properties file
 
@@ -162,8 +152,7 @@ jobs:
     uses: urbansportsclub/usc-reusable-workflows/.github/workflows/sonarqube-scan.yaml@main
     with:
       download_coverage_artifact: true
-    secrets:
-      token: ${{ secrets.SONAR_TOKEN }}
+    secrets: inherit
 ```
 
 Here is an example on how to use SonarQube for the `master|main` branch. You can notice that we are exposing two inputs for the `scan`:
@@ -193,8 +182,7 @@ jobs:
     with:
       enable_quality_gate: false
       download_coverage_artifact: true
-    secrets:
-      token: ${{ secrets.SONAR_TOKEN }}
+    secrets: inherit
 ```
 
 ### Code coverage for other languages
@@ -222,8 +210,7 @@ scan:
     enable_quality_gate: true
     download_coverage_artifact: true
     coverage_artifact_name: php-coverage-xml
-  secrets:
-    token: ${{ secrets.SONAR_TOKEN }}
+  secrets: inherit
 ```
 
 


### PR DESCRIPTION
We moved the sonar token secret to the organization level and renamed the variable for better naming