### PR TITLE
run go tests in short mode

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -48,7 +48,7 @@ jobs:
       run: ${{ inputs.external_container_dependencies }}
 
     - name: Test
-      run: go test -v -race -covermode=atomic -coverprofile=coverage.out ./...
+      run: go test -v -race -short -covermode=atomic -coverprofile=coverage.out ./...
       env:
         GITHUB_TOKEN: ${{ secrets.github-token }}
     


### PR DESCRIPTION
There is an issue with container implementations that are affected with changes in the standard library. More here https://github.com/testcontainers/testcontainers-go/issues/1359, for the meantime, while https://github.com/moby/moby/pull/45942 is not merged and https://github.com/testcontainers/testcontainers-go/issues/1359#issuecomment-1632456255 is not followed, we cannot block our engineers. For this reason, I am adding the flag `-short` to avoid running all the container specific tests.