### PR TITLE
downgrade golang version and remove -short

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v4
       with:
-        go-version: "stable"
+        go-version: "1.20.5"
 
     - name: Checkout code
       uses: actions/checkout@v3
@@ -48,7 +48,7 @@ jobs:
       run: ${{ inputs.external_container_dependencies }}
 
     - name: Test
-      run: go test -v -race -short -covermode=atomic -coverprofile=coverage.out ./...
+      run: go test -v -race -covermode=atomic -coverprofile=coverage.out ./...
       env:
         GITHUB_TOKEN: ${{ secrets.github-token }}
     


### PR DESCRIPTION
To re-enable the execution of integration test, we can downgrade go version one patch before, since the issue related with the containers was caused in the version 1.20.6 as mentioned here https://github.com/testcontainers/testcontainers-go/issues/1359#issuecomment-1632858266 and here https://github.com/testcontainers/testcontainers-go/issues/1359#issuecomment-1632866663