### PR TITLE
stable version for golang

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.20.5"
+        go-version: "stable"
 
     - name: Checkout code
       uses: actions/checkout@v3


### PR DESCRIPTION
Since the issues from last time were fixed and new projects can easily update their dependencies from testcontainers' issue, we can return to the stable version and have the new features from Go 1.21 available for usage.