### PR TITLE
Error with setup.go and cache

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -29,6 +29,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: "stable"
+        cache: false
 
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -25,14 +25,13 @@ jobs:
     timeout-minutes: 15
 
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Setup go
       uses: actions/setup-go@v5
       with:
         go-version: "stable"
-        cache: false
-
-    - name: Checkout code
-      uses: actions/checkout@v4
     
     - uses: actions/cache@v4
       with:


### PR DESCRIPTION
It will fix the [following error](https://github.com/actions/setup-go/issues/427) in many CI runs.
![SCR-20240201-lbbz](https://github.com/urbansportsclub/usc-reusable-workflows/assets/1439984/b23efbeb-eabc-4a18-ae9e-e9429a15b07b)
