### PR TITLE
task: Pin golang-ci-lint to non-broken version

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Lint Code Base
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: v1.55
           only-new-issues: true
           args: -c ./.github/linters/.golangci.yaml
         env:


### PR DESCRIPTION
`golangci-lint` introduced [an issue](https://github.com/golangci/golangci-lint/issues/4353) in v1.56 which causes our linter workflow to fail with the following:

```bash
level=error msg="Running error: can't run linter goanalysis_metalinter\nthe_only_name: cannot find rule: enforce-repeated-arg-type-style"
```

This will likely be fixed in a v1.56.1 release of the tool soon. And, there is a [documented work-around](https://github.com/golangci/golangci-lint/issues/4353#issuecomment-1932470454) that each project can adopt in their `.golangci.yaml` file. However, to unblock everyone at once, the best option, I think, is to pin us to the previous release.

We should be aware that we don't get too far behind on versions though!

Note, per the [action docs](https://github.com/marketplace/actions/run-golangci-lint), a version identifier of just major/minor is acceptable when using the `binary` install option. That's the default so this should be fine (with the `goinstall` install mode then the revision is required as well)