### PR TITLE
internal automerge

### DIFF
--- a/.github/workflows/internal-automerge.yaml
+++ b/.github/workflows/internal-automerge.yaml
@@ -1,0 +1,14 @@
+---
+#This is NOT a reusable workflow
+name: Automerge Dependabot PRs
+on:
+  pull_request:
+    branches:
+      - "*"
+jobs:
+  # execute the automerge for dependabot PRs
+  automerge:
+    name: Automerge Dependabot
+    uses: urbansportsclub/usc-reusable-workflows/.github/workflows/automerge-dependabot.yml@main
+    secrets:
+      github-token: ${{ secrets.USG_GITHUB_TOKEN }}


### PR DESCRIPTION
# added an internat automerge workflow

The internal automerge is supposed to work in this repo and not as a reusable workflow. As of today, github actions does not support having folders inside the workflows folder so I added a comment to specify that this workflow is for internal use. 
