### PR TITLE
fix linter issue

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -35,6 +35,10 @@ on:
         required: false
         type: boolean
         default: false
+      enable_whole_files:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   build:
@@ -89,6 +93,6 @@ jobs:
         with:
           version: v1.55
           only-new-issues: true
-          args: -c ./.github/linters/.golangci.yaml
+          args: -c ./.github/linters/.golangci.yaml ${{inputs.enable_whole_files && '--whole-files'}}
         env:
           GITHUB_TOKEN: ${{ secrets.github-token }}

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -93,6 +93,6 @@ jobs:
         with:
           version: v1.55
           only-new-issues: true
-          args: -c ./.github/linters/.golangci.yaml ${{inputs.enable_whole_files && '--whole-files'}}
+          args: -c ./.github/linters/.golangci.yaml ${{inputs.enable_whole_files && '--whole-files' || ''}}
         env:
           GITHUB_TOKEN: ${{ secrets.github-token }}

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Lint Code Base
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.55
+          version: v1.56
           only-new-issues: true
           args: -c ./.github/linters/.golangci.yaml ${{inputs.enable_whole_files && '--whole-files' || ''}}
         env:

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Lint Code Base
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.56
+          version: latest
           only-new-issues: true
           args: -c ./.github/linters/.golangci.yaml ${{inputs.enable_whole_files && '--whole-files' || ''}}
         env:


### PR DESCRIPTION
In the linter reusable workflow there is an option **only-new-issues** which is set to **true** which means that only new issues will be reported if it’s a pull request.
But this option generates golangci-lint command using **—new-from-patch** option which will make linter to skip the issues if they are not reported as the same line as the changes (it uses git diff, the issue is described here: https://golangci-lint.run/usage/faq/#why---new-from-rev-or---new-from-patch-dont-seem-to-be-working-in-some-cases).

As a fix, we have added new input for linter reusable workflow **enable_whole_files** which, if set to **true**, includes **—whole-files** option which makes linter to show the issues in any part of files that are updated. This may lead for some old issues that weren’t reported before to be reported now, but teams can set it to false if they don't want to deal with it right now.