### PR TITLE
Build without pushing

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yaml
+++ b/.github/workflows/build-and-push-docker-image.yaml
@@ -54,6 +54,10 @@ on:
         type: boolean
         default: false
         required: false
+      push:
+        type: boolean
+        default: true
+        required: false        
     secrets:
       build_args:
         required: false
@@ -113,7 +117,7 @@ jobs:
         target: ${{ inputs.target }}
         build-args: |
           ${{ secrets.build_args }}
-        push: true
+        push: false
         tags: ${{ steps.subscriber_meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/build-and-push-docker-image.yaml
+++ b/.github/workflows/build-and-push-docker-image.yaml
@@ -117,7 +117,7 @@ jobs:
         target: ${{ inputs.target }}
         build-args: |
           ${{ secrets.build_args }}
-        push: false
+        push: ${{ inputs.push }}
         tags: ${{ steps.subscriber_meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=local,src=/tmp/.buildx-cache


### PR DESCRIPTION
We allow to set the push to false in case someone wants to build their image without pushing to the registry (for example, for testing or to check for build errors).

The default value is true so this will not affect any existing project using this action.