### PR TITLE
Add Custom Download Path Value to Sonarqube Download Artifact

### DIFF
--- a/.github/workflows/sonarqube-scan.yaml
+++ b/.github/workflows/sonarqube-scan.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Download code coverage results
         if: inputs.download_coverage_artifact == true
@@ -45,10 +45,6 @@ jobs:
         with:
           name: ${{ inputs.coverage_artifact_name }}
           path: ${{inputs.artifact_download_path}}
-
-      # DEBUGGING
-      - name: Echo directory contents
-        run: ls -alh
 
       - name: Scan
         uses: sonarsource/sonarqube-scan-action@master
@@ -58,7 +54,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ inputs.url }}
-    
+
       - name: Scan
         uses: sonarsource/sonarqube-scan-action@master
         if: ${{ always() && github.ref != format('refs/heads/{0}', env.REFERENCE_BRANCH) }}

--- a/.github/workflows/sonarqube-scan.yaml
+++ b/.github/workflows/sonarqube-scan.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.coverage_artifact_name }}
+          path: ./coverage
 
       # DEBUGGING
       - name: Echo directory contents

--- a/.github/workflows/sonarqube-scan.yaml
+++ b/.github/workflows/sonarqube-scan.yaml
@@ -20,6 +20,9 @@ on:
         required: false
         type: string
         default: coverage-artifact
+      artifact_download_path:
+        required: false
+        type: string
       reference_branch:
         required: false
         type: string
@@ -41,7 +44,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.coverage_artifact_name }}
-          path: ./coverage
+          path: ${{inputs.artifact_download_path}}
 
       # DEBUGGING
       - name: Echo directory contents

--- a/.github/workflows/sonarqube-scan.yaml
+++ b/.github/workflows/sonarqube-scan.yaml
@@ -42,6 +42,10 @@ jobs:
         with:
           name: ${{ inputs.coverage_artifact_name }}
 
+      # DEBUGGING
+      - name: Echo directory contents
+        run: ls -alh
+
       - name: Scan
         uses: sonarsource/sonarqube-scan-action@master
         if: ${{ always() && github.ref == format('refs/heads/{0}', env.REFERENCE_BRANCH) }}

--- a/.github/workflows/unit-test-js.yml
+++ b/.github/workflows/unit-test-js.yml
@@ -92,6 +92,10 @@ jobs:
           PKG_CMD: ${{ env.NODE_CMD_MODE == 'npm' && 'npm run' || env.NODE_CMD_MODE }}
         run: ${{ format('{0} {1}{2}', env.PKG_CMD, 'test', inputs.TEST_CMD_FLAG) }}
 
+      # DEBUGGING
+      - name: Echo directory contents
+        run: ls -alh
+
       - name: Upload coverage artifacts to `${{ inputs.WORKING_DIRECTORY }}/coverage/test-artifacts`
         if: ${{ inputs.UPLOAD_ARTIFACTS }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/unit-test-js.yml
+++ b/.github/workflows/unit-test-js.yml
@@ -92,10 +92,6 @@ jobs:
           PKG_CMD: ${{ env.NODE_CMD_MODE == 'npm' && 'npm run' || env.NODE_CMD_MODE }}
         run: ${{ format('{0} {1}{2}', env.PKG_CMD, 'test', inputs.TEST_CMD_FLAG) }}
 
-      # DEBUGGING
-      - name: Echo directory contents
-        run: ls -alh
-
       - name: Upload coverage artifacts to `${{ inputs.WORKING_DIRECTORY }}/coverage/test-artifacts`
         if: ${{ inputs.UPLOAD_ARTIFACTS }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Add Custom Download Path Value to Sonarqube Download Artifact

- When using `download-artifact` with only the `name` value, it will download all files / directories within the artifact to the root of the project folder
- Should make use of the `path:`  value when we want to, to allow for the files to be downloaded to a custom dir
- This is useful with Sonarqube as we can then point our `sonar.javascript.lcov.reportPaths` to a specific directory
- e.g.
- `sonar.javascript.lcov.reportPaths=./coverage/lcov.info`